### PR TITLE
Use a custom HTML legend instead of the Chart.js built-in one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "internal_dashboard",
-  "version": "0.0.0",
+  "name": "siorgp_public_dashboard",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "internal_dashboard",
-      "version": "0.0.0",
+      "name": "siorgp_public_dashboard",
+      "version": "1.0.1",
       "dependencies": {
         "chart.js": "^4.4.3",
         "gridjs": "^6.2.0"

--- a/src/ccp.css
+++ b/src/ccp.css
@@ -116,6 +116,14 @@ header h1 {
   background-color: var(--white);
 }
 
+/* Can be reused to style any container that should look like a card: white background, border with rounded corners */
+.card {
+  background-color: var(--white);
+  border: solid 1px var(--lightest-gray);
+  border-radius: var(--border-radius-small);
+  margin: var(--gap-xs);
+}
+
 #card1, #card2, #card3, #card4 {
   display: flex;
   flex-direction: column;
@@ -124,55 +132,6 @@ header h1 {
   text-align: center;
   border-radius: var(--border-radius-small);
   background-color: var(--white);
-}
-
-#dashWrapper {  
-  justify-items: center;
-  text-align: center;  
-  display: grid;
-  grid-template-rows: repeat(2, 1fr);
-  grid-gap: var(--gap-s);
-  border-radius: var(--border-radius-small);    
-  padding: var(--gap-xs);
-  align-items: stretch;
-}
-
-.chartWrapper {
-  width: 100%;
-  border-radius: var(--border-radius-small);
-  border: solid 1px var(--lightest-gray);
-  background-color: var(--white);
-  align-items: center;
-  justify-content: center;
-}
-
-#chartsTopRow {    
-  display: grid;
-  justify-items: center;  
-  align-items: stretch;
-  grid-template-columns: 33% 33% 33%;   
-}
-
-#chartsBottomRow {  
-  display: grid;  
-  justify-items: center;
-  align-items: stretch;
-  grid-template-columns: repeat(4, 25%);  
-}
-
-.barChart, .pieChart {
-  width: 80%;
-  height: 100%;
-  background-color: var(--white);
-  /*
-  border-radius: var(--border-radius-small);    
-  border: solid 1px var(--lightest-gray);  
-  */
-}
-
-.barChart canvas, .pieChart canvas {
-  max-height: 400px;
-  width: 100%;
 }
 
 @media screen and (max-width: 1200px) {

--- a/src/htmlLegendPlugin.ts
+++ b/src/htmlLegendPlugin.ts
@@ -1,0 +1,56 @@
+import { Chart } from 'chart.js';
+
+// We are using a custom HTML legend (see https://www.chartjs.org/docs/latest/samples/legend/html.html)
+// instead of the built-in legend rendering of Chart.js. This gives us more flexibilty in styling the legend,
+// specifically it allows us to separately lay out the pie charts and their legends for a consistent
+// sizing and alignment of charts.
+
+export function makeHtmlLegendPlugin(legendContainerId: string) {
+  return {
+    id: 'htmlLegend',
+    afterUpdate(chart: Chart) {
+      const legendContainer = document.getElementById(legendContainerId)!;
+      legendContainer.innerHTML = '';
+
+      const items = chart.options.plugins!.legend!.labels!.generateLabels!(chart);
+      for (const item of items) {
+        const legendItem = document.createElement('div');
+        legendItem.style.alignItems = 'center';
+        legendItem.style.cursor = 'pointer';
+        legendItem.style.display = 'flex';
+        legendItem.style.flexDirection = 'row';
+        legendItem.style.fontSize = 'var(--font-size-xs)';
+
+        legendItem.onclick = () => {
+          chart.toggleDataVisibility(item.index!);
+          chart.update();
+        };
+
+        // Color box
+        const boxSpan = document.createElement('span');
+        boxSpan.style.background = item.fillStyle!.toString();
+        boxSpan.style.borderColor = item.strokeStyle!.toString();
+        boxSpan.style.borderWidth = item.lineWidth + 'px';
+        boxSpan.style.display = 'inline-block';
+        boxSpan.style.flexShrink = '0';
+        boxSpan.style.height = '20px';
+        boxSpan.style.marginRight = '10px';
+        boxSpan.style.width = '20px';
+
+        // Text
+        const textContainer = document.createElement('p');
+        textContainer.style.color = item.fontColor!.toString();
+        textContainer.style.margin = '0';
+        textContainer.style.padding = '0';
+        textContainer.style.textDecoration = item.hidden ? 'line-through' : '';
+
+        const text = document.createTextNode(item.text);
+        textContainer.appendChild(text);
+
+        legendItem.appendChild(boxSpan);
+        legendItem.appendChild(textContainer);
+        legendContainer.appendChild(legendItem);
+      }
+    }
+  };
+}

--- a/src/index.html
+++ b/src/index.html
@@ -53,41 +53,37 @@
             </div>
         </div>
     </div>
-    <!-- patient data bar chart -->
-    <div id="dashWrapper">
-        <div id="chartsTopRow" class="chartWrapper">
-            <div id="patientsByProjectBarChart" class="barChart">
-                <h4>Patients by Project</h4>
-                <canvas id="patientsByProjectBarChartCanvas"></canvas>
-            </div>
-            <div id="organoidsByProjectBarChart" class="barChart">
-                <h4>Organoids by Project</h4>
-                <canvas id="organoidsByProjectBarChartCanvas"></canvas>
-            </div>
-            <div id="patientsByAgeBarChart" class="barChart">
-                <h4>Patients Age Distribution</h4>
-                <canvas id="patientsByAgeBarChartCanvas"></canvas>
-            </div>                
-        </div>
-        <div id="chartsBottomRow" class="chartWrapper">
-            <div id="patientsByGenderPieChart" class="pieChart">
-                <h4>Patients by Gender</h4>
-                <canvas id="patientsByGenderPieChartCanvas"></canvas>
-            </div>
-            <div id="organoidByBiopsySitePieChart" class="pieChart">
-                <h4>Organoids by Biopsy Site</h4>
-                <canvas id="organoidByBiopsySitePieChartCanvas"></canvas>
-            </div>
-            <div id="metPPatientsByPdosPieChart" class="pieChart">
-                <h4>MetP Patients by PDOs</h4>
-                <canvas id="metPPatientsByPdosPieChartCanvas"></canvas>
-            </div>
-            <div id="neoMPatientsByTherapyStatusPieChart" class="pieChart">
-                <h4>NeoM Patients: PDOs by Therapy Status</h4>
-                <canvas id="neoMPatientsByTherapyStatusPieChartCanvas"></canvas>
-            </div>                
-        </div>      
-    </div>            
+
+    <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--gap-s); padding: var(--gap-s);" class="card">
+      <h4 style="text-align: center;">Patients by Project</h4>
+      <h4 style="text-align: center;">Organoids by Project</h4>
+      <h4 style="text-align: center;">Patients Age Distribution</h4>
+
+      <!-- For responsive charts, Charts.js requires a dedicated container for each canvas: https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note -->
+      <!-- The container requires `min-width: 0` if it is a flexbox item or CSS grid item: https://github.com/chartjs/Chart.js/issues/4156#issuecomment-295180128 -->
+      <div style="min-width: 0;"><canvas id="patientsByProjectBarChartCanvas"></canvas></div>
+      <div style="min-width: 0;"><canvas id="organoidsByProjectBarChartCanvas"></canvas></div>
+      <div style="min-width: 0;"><canvas id="patientsByAgeBarChartCanvas"></canvas></div>
+    </div>
+
+    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--gap-s); padding: var(--gap-s);" class="card">
+      <h4 style="text-align: center;">Patients by Gender</h4>
+      <h4 style="text-align: center;">Organoids by Biopsy Site</h4>
+      <h4 style="text-align: center;">MetP Patients by PDOs</h4>
+      <h4 style="text-align: center;">NeoM Patients: PDOs by Therapy Status</h4>
+
+      <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: var(--gap-xs);" id="patientsByGenderPieChartLegend"></div>
+      <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: var(--gap-xs);" id="organoidByBiopsySitePieChartLegend"></div>
+      <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: var(--gap-xs);" id="metPPatientsByPdosPieChartLegend"></div>
+      <div style="display: flex; flex-wrap: wrap; justify-content: center; gap: var(--gap-xs);" id="neoMPatientsByTherapyStatusPieChartLegend"></div>
+
+      <!-- For responsive charts, Charts.js requires a dedicated container for each canvas: https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note -->
+      <!-- The container requires `min-width: 0` if it is a flexbox item or CSS grid item: https://github.com/chartjs/Chart.js/issues/4156#issuecomment-295180128 -->
+      <div style="min-width: 0;"><canvas id="patientsByGenderPieChartCanvas"></canvas></canvas></div>
+      <div style="min-width: 0;"><canvas id="organoidByBiopsySitePieChartCanvas"></canvas></div>
+      <div style="min-width: 0;"><canvas id="metPPatientsByPdosPieChartCanvas"></canvas></div>
+      <div style="min-width: 0;"><canvas id="neoMPatientsByTherapyStatusPieChartCanvas"></canvas></div>
+    </div>
   </main>
   <footer>
       <a

--- a/src/initCharts.ts
+++ b/src/initCharts.ts
@@ -1,4 +1,5 @@
 import { Chart, ChartData, ChartOptions as ChartJsOptions } from 'chart.js';
+import { makeHtmlLegendPlugin } from './htmlLegendPlugin';
 
 interface ChartOptions {
   type: 'bar' | 'pie';
@@ -17,10 +18,10 @@ function createChart(canvasId: string, options: ChartOptions) {
 
   const chartOptions: ChartJsOptions = {
     responsive: true,
-    maintainAspectRatio: true,
+    maintainAspectRatio: false,
     plugins: {
       legend: {
-        display: true
+        display: false,
       },
       tooltip: {
         callbacks: {
@@ -63,7 +64,8 @@ function createChart(canvasId: string, options: ChartOptions) {
         { data: options.data }
       ]
     },
-    options: chartOptions
+    options: chartOptions,
+    plugins: options.type === 'pie' ? [makeHtmlLegendPlugin(canvasId.replace('Canvas', 'Legend'))] : [],
   });
 }
 


### PR DESCRIPTION
The Chart.js built-in legend render will dynamically take away space from the pie chart to render the legend. If legend entries wrap over multiple lines this will take away space from the pie chart, leading to inconsistent sizing of pie charts when the browser window is resized. This PR implements custom HTML legend as described here: https://www.chartjs.org/docs/latest/samples/legend/html.html

The result is that the pie charts are always equally sized. This does introduce some complexity, so I can't say if it's worth it.

If I know that I won't reuse CSS styles I tend to use inline styles à la Tailwind CSS philosophy. If you don't like it I will move the styles out into their own classes.

I've also changed the way CSS grid is used. There is now 1 grid for the bar charts and 1 grid for the pie charts. Screenshot with CSS grid debug overlay:

![image](https://github.com/user-attachments/assets/c7c93d84-4245-4a45-ab0a-e5648a908100)
